### PR TITLE
Fix bug that prevented /etc/rvmrc from being used

### DIFF
--- a/lib/rvm/shell/calculate_rvm_path.sh
+++ b/lib/rvm/shell/calculate_rvm_path.sh
@@ -11,7 +11,7 @@ fi
 # Load extra files.
 
 [[ -s ~/.rvmrc ]] && source ~/.rvmrc >/dev/null 2>&1
-[[ -s /etc/.rvmrc ]] && source /etc/rvmrc >/dev/null 2>&1
+[[ -s /etc/rvmrc ]] && source /etc/rvmrc >/dev/null 2>&1
 
 if [[ -n "$rvm_path" ]]; then
   echo "$rvm_path"


### PR DESCRIPTION
This wasn't playing nice with the ironfan-pantry "rvm" cookbook, which depends on /etc/rvmrc as its Source Of Truth (tm). This one-character typo fix makes everyone play nice together.
