### PR TITLE
Use :rvm_path config approriately instead of always defers to environment variable

### DIFF
--- a/lib/rvm/environment/utility.rb
+++ b/lib/rvm/environment/utility.rb
@@ -66,7 +66,8 @@ module RVM
       args += hash_to_options(options)
       args.map! { |a| a.to_s }
 
-      program = rvm_by_path ? "#{self.class.default_rvm_path}/bin/rvm" : "rvm"
+      rvm_path = config_value_for(:rvm_path, self.class.default_rvm_path, false)
+      program = rvm_by_path ? "#{rvm_path}/bin/rvm" : "rvm"
       if silent
         run_silently(program, *args)
       else


### PR DESCRIPTION
Related to
- https://github.com/wayneeseguin/rvm/issues/1466
- https://github.com/wayneeseguin/rvm-gem/pull/11
- https://github.com/fnichol/chef-rvm/issues/159

This uses `rvm_path` config when possible instead of depending of `self.class. default_rvm_path` which afaik only works when rvm is sourced / `source_rvm_environment` is called ( which is not the case when `:rvm_by_path` is used  in chef-rvm)
