### PR TITLE
Support for :rubygem_version option to #rvm helper

### DIFF
--- a/lib/rvm/environment/utility.rb
+++ b/lib/rvm/environment/utility.rb
@@ -55,19 +55,21 @@ module RVM
     #  rvm :use, "ree@rails3", :install => true
     #  > rvm use ree@rails3 --install
     #
-    #  rvm :install, "ree@rails3", :rvm_by_path => true
-    #  > $rvm_path/bin/rvm install ree@rails3
+    #  rvm :install, "ree@rails3", :rvm_by_path => true, :rubygems_version => "1.8.23"
+    #  > rvm_rubygems_version=1.8.23 $rvm_path/bin/rvm install ree@rails3
     #
     def rvm(*args)
       options = extract_options!(args)
       silent = options.delete(:silent)
       rvm_by_path = options.delete(:rvm_by_path)
+      rubygems_version = options.delete(:rubygems_version)
       rearrange_options!(args, options)
       args += hash_to_options(options)
       args.map! { |a| a.to_s }
 
       rvm_path = config_value_for(:rvm_path, self.class.default_rvm_path, false)
       program = rvm_by_path ? "#{rvm_path}/bin/rvm" : "rvm"
+      program = "rvm_rubygems_version=#{rubygems_version} #{program}" if rubygems_version
       if silent
         run_silently(program, *args)
       else


### PR DESCRIPTION
Patch to support installing a rvm ruby with a specified :rubygems_version.

See: https://github.com/fnichol/chef-rvm/pull/252

In the context of provisioning, it's desirable to lock in specific rvm version, rubies, and rubygem versions. Needed this patch to avoid the error below when doing so.

> There is no checksum for 'http://production.cf.rubygems.org/rubygems/rubygems-2.0.14.tgz' or 'rubygems-2.0.14.tgz', it's not possible to validate it.
> This could be because your RVM install's list of versions is out of date. You may want to
> update your list of rubies by running 'rvm get stable' and try again.
> If that does not resolve the issue and you wish to continue with unverified download
> add '--verify-downloads 1' after the command.
> 
> There has been an error while trying to fetch rubygems. 
> Halting the installation.
